### PR TITLE
[add] Nodes func to only get nodes list; [add] Lock/Unlock in Get func

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 *.dylib
 *.test
 *.out
+.idea/

--- a/binarytree.go
+++ b/binarytree.go
@@ -62,6 +62,9 @@ func (receiver *Tree) ToggleCanConnect(node interface{}) {
 }
 
 func (receiver *Tree) Get(node interface{}) SingleNode {
+	receiver.mutex.Lock()
+	defer receiver.mutex.Unlock()
+
 	return receiver.nodes[node]
 }
 
@@ -99,6 +102,17 @@ func (receiver *Tree) All() map[interface{}]SingleNode {
 	defer receiver.mutex.Unlock()
 
 	return receiver.nodes
+}
+
+func (receiver *Tree) Nodes() []SingleNode {
+	receiver.mutex.Lock()
+	defer receiver.mutex.Unlock()
+
+	var nodes []SingleNode
+	for _, node := range receiver.nodes {
+		nodes = append(nodes, node)
+	}
+	return nodes
 }
 
 func (receiver *Tree) LevelNodes(level uint) []SingleNode {

--- a/binarytree.go
+++ b/binarytree.go
@@ -68,6 +68,10 @@ func (receiver *Tree) Get(node interface{}) SingleNode {
 	return receiver.nodes[node]
 }
 
+func (receiver *Tree) get(node interface{}) SingleNode{
+	return receiver.nodes[node]
+}
+
 func (receiver *Tree) Delete(node interface{}) {
 	receiver.mutex.Lock()
 	defer receiver.mutex.Unlock()
@@ -140,7 +144,7 @@ func (receiver *Tree) LevelNodes(level uint) []SingleNode {
 		output = []SingleNode{}
 		for _, nodes := range currentLevelNodes {
 			for indx := range nodes.All() {
-				child := receiver.Get(indx)
+				child := receiver.get(indx)
 				if child.CanConnect() {
 					output = append(output, child)
 				}

--- a/binarytree_test.go
+++ b/binarytree_test.go
@@ -277,6 +277,38 @@ func TestWebSocketMap_GetAll(t *testing.T) {
 	}
 }
 
+func TestWebSocketMap_GetNodes(t *testing.T) {
+	var websocketmaps Tree = Tree{}
+	websocketmaps.SetFillNode(fillFunction)
+
+	tests := []struct {
+		Input *websocket.Conn
+
+		ExpectedLen int
+	}{
+		{
+			Input:       &websocket.Conn{},
+			ExpectedLen: 1,
+		},
+		{
+			Input:       &websocket.Conn{},
+			ExpectedLen: 2,
+		},
+		{
+			Input:       &websocket.Conn{},
+			ExpectedLen: 3,
+		},
+	}
+
+	for testNumber, test := range tests {
+		websocketmaps.Insert(test.Input)
+		allNodes := websocketmaps.Nodes()
+		if len(allNodes) != test.ExpectedLen {
+			t.Errorf("Test %d :  %d was expected but got %d", testNumber, test.ExpectedLen, len(allNodes))
+		}
+	}
+}
+
 func TestWebSocketMap_LevelNodes(t *testing.T) {
 	var websocketmaps Tree = Tree{}
 	websocketmaps.SetFillNode(fillFunction)


### PR DESCRIPTION
1. needed to get a copy of the `Tree.nodes` entries so we are not returning the reference
2. added lock/unlock at the `Get` func head
3. fixed a deadlock bug in `LevelNode` func
4. added unit test for `Nodes` func
5. made sure all tests are passed using `go test ./...`